### PR TITLE
Fix WU page on 11

### DIFF
--- a/lib/screens/pages/updates_page.dart
+++ b/lib/screens/pages/updates_page.dart
@@ -61,14 +61,10 @@ class _UpdatesPageState extends State<UpdatesPage> {
                     writeRegistryString(Registry.localMachine, r'SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer', 'SettingsPageVisibility',
                         "hide:cortana;privacy-automaticfiledownloads;privacy-feedback;windowsinsider-optin;windowsinsider;windowsupdate");
                     writeRegistryDword(Registry.localMachine, r'SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer', 'IsWUHidden', 1);
-                    await Process.run('taskkill.exe', ['/im', 'explorer.exe', '/f']);
-                    await Process.run('explorer.exe', [], runInShell: true);
                   } else {
                     writeRegistryString(Registry.localMachine, r'SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer', 'SettingsPageVisibility',
-                        "hide:cortana;privacy-automaticfiledownloads;privacy-feedback;windowsinsider-optin;");
+                        "hide:cortana;privacy-automaticfiledownloads;privacy-feedback;");
                     writeRegistryDword(Registry.localMachine, r'SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer', 'IsWUHidden', 0);
-                    await Process.run('taskkill.exe', ['/im', 'explorer.exe', '/f']);
-                    await Process.run('explorer.exe', [], runInShell: true);
                   }
                 },
               ),


### PR DESCRIPTION
On Windows 11, hiding `windowsinsider-optin` and/or `windowsinsider` makes the WU page to disappear.

Resolves #8

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/meetrevision/revision-tool/issues) for my issue
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Discussed about the issue with reviewers in Discussions, Issues or other platforms 
- [x] Confirmed that the PR only includes changes related to my issue
- [x] Checked the PR locally: `flutter build windows` (Request it to reviewers if you're having problems)