### PR TITLE
fix: wrong value in "new context menu"

### DIFF
--- a/lib/screens/pages/usability_page_two.dart
+++ b/lib/screens/pages/usability_page_two.dart
@@ -55,22 +55,20 @@ class _UsabilityPageTwoState extends State<UsabilityPageTwo> {
                   setState(() {
                     mrcBool = value;
                   });
-                  if (mrcBool) {
+                  if (value) {
                     Shell().run(r'''
-                            reg add "HKCU\Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32" /ve /t REG_SZ /d "" /f
-	                          reg add "HKLM\Software\Classes\CLSID" /v "IsModernRCEnabled" /t REG_DWORD /d "0" /f
-                        ''');
-                    // createRegistryKey(Registry.currentUser, r'Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32');
-                    // writeRegistryDword(Registry.localMachine, r'Software\Classes\CLSID', 'IsModernRCEnabled', 1);
+                            reg delete "HKCU\Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}" /f
+                    ''');
+                    // Error 0x80070005: Access is denied.
+                    // deleteRegistryKey(Registry.currentUser, r'Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}');
+                    writeRegistryDword(Registry.localMachine, r'Software\Classes\CLSID', 'IsModernRCEnabled', 1);
+
                     await Process.run('taskkill.exe', ['/im', 'explorer.exe', '/f']);
                     await Process.run('explorer.exe', [], runInShell: true);
                   } else {
-                    // deleteRegistryKey(Registry.currentUser, r'Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32');
-                    // writeRegistryDword(Registry.localMachine, r'Software\Classes\CLSID', 'IsModernRCEnabled', 0);
-                    Shell().run(r'''
-                            reg add "HKLM\Software\Classes\CLSID" /v "IsModernRCEnabled" /t REG_DWORD /d "1" /f
-                            reg delete "HKCU\Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}" /f
-                        ''');
+                    createRegistryKey(Registry.currentUser, r'Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32');
+                    writeRegistryString(Registry.currentUser, r'Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32', '', '');
+                    writeRegistryDword(Registry.localMachine, r'Software\Classes\CLSID', 'IsModernRCEnabled', 0);
                     await Process.run('taskkill.exe', ['/im', 'explorer.exe', '/f']);
                     await Process.run('explorer.exe', [], runInShell: true);
                   }


### PR DESCRIPTION
Resolves #10

- Set the default value of `InprocServer32` to blank
- Remove `Shell()`  call when disabling option
- Fix `IsModernRCEnabled` wrong value

## Submitter Checklist:

- [X] There is a [ticket](https://github.com/meetrevision/revision-tool/issues) for my issue
- [X] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [X] Discussed about the issue with reviewers in Discussions, Issues or other platforms 
- [X] Confirmed that the PR only includes changes related to my issue
- [X] Checked the PR locally: `flutter build windows` (Request it to reviewers if you're having problems)