### PR TITLE
flutter_window: Remove unused std::optional

### DIFF
--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -43,11 +43,12 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
                               LPARAM const lparam) noexcept {
   // Give Flutter, including plugins, an opportunity to handle window messages.
   if (flutter_controller_) {
-    std::optional<LRESULT> result =
+    bool handled = false;
+    LRESULT result =
         flutter_controller_->HandleTopLevelWindowProc(hwnd, message, wparam,
-                                                      lparam);
-    if (result) {
-      return *result;
+                                                      lparam, &handled);
+    if (handled) {
+      return result;
     }
   }
 


### PR DESCRIPTION
The std::optional in the MessageHandler function is not used, so it can be removed.