### PR TITLE
Fix Revision Tools Battery Health Reporting disabling issue.

### DIFF
--- a/lib/screens/pages/miscellaneous_page.dart
+++ b/lib/screens/pages/miscellaneous_page.dart
@@ -211,8 +211,6 @@ class _MiscellaneousPageState extends State<MiscellaneousPage> {
               writeRegistryDword(Registry.localMachine,
                   r'SYSTEM\ControlSet001\Services\DPS', 'Start', 2);
               writeRegistryDword(Registry.localMachine,
-                  r'SYSTEM\ControlSet001\Services\Ndu', 'Start', 2);
-              writeRegistryDword(Registry.localMachine,
                   r'SYSTEM\ControlSet001\Services\diagsvc', 'Start', 2);
               writeRegistryDword(Registry.localMachine,
                   r'SYSTEM\ControlSet001\Services\WdiServiceHost', 'Start', 2);
@@ -226,8 +224,6 @@ class _MiscellaneousPageState extends State<MiscellaneousPage> {
             } else {
               writeRegistryDword(Registry.localMachine,
                   r'SYSTEM\ControlSet001\Services\DPS', 'Start', 4);
-              writeRegistryDword(Registry.localMachine,
-                  r'SYSTEM\ControlSet001\Services\Ndu', 'Start', 4);
               writeRegistryDword(Registry.localMachine,
                   r'SYSTEM\ControlSet001\Services\diagsvc', 'Start', 4);
               writeRegistryDword(Registry.localMachine,


### PR DESCRIPTION
Remove duplicates and add necessary registry settings in both enabling and disabling side.
test these registry on ReviOS 11 23.05

## Submitter Checklist:

- [ ] There is a [ticket](https://github.com/meetrevision/revision-tool/issues) for my issue
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Discussed about the issue with reviewers in Discussions, Issues or other platforms 
- [ ] Confirmed that the PR only includes changes related to my issue
- [ ] Checked the PR locally: `flutter build windows` (Request it to reviewers if you're having problems)