### PR TITLE
fix: Clear up Caps Lock key confusion

### DIFF
--- a/lib/l10n/generated/localizations.dart
+++ b/lib/l10n/generated/localizations.dart
@@ -295,10 +295,10 @@ abstract class ReviLocalizations {
   /// **'Windows will learn what you type to improve suggestions when writing'**
   String get usabilityITPDescription;
 
-  /// The label for CapsLock Key
+  /// The label for disabling the CapsLock Key
   ///
   /// In en, this message translates to:
-  /// **'CapsLock Key'**
+  /// **'Disable CapsLock Key'**
   String get usabilityCPLLabel;
 
   /// The label for New Context Menu

--- a/lib/l10n/generated/localizations_en.dart
+++ b/lib/l10n/generated/localizations_en.dart
@@ -107,7 +107,7 @@ class ReviLocalizationsEn extends ReviLocalizations {
   String get usabilityITPDescription => 'Windows will learn what you type to improve suggestions when writing';
 
   @override
-  String get usabilityCPLLabel => 'CapsLock Key';
+  String get usabilityCPLLabel => 'Disable CapsLock Key';
 
   @override
   String get usability11MRCLabel => 'New Context Menu';

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -136,9 +136,9 @@
   "@usabilityITPDescription": {
     "description": "The description for Inking And Typing Personalization"
   },
-  "usabilityCPLLabel": "CapsLock Key",
+  "usabilityCPLLabel": "Disable CapsLock Key",
   "@usabilityCPLLabel": {
-    "description": "The label for CapsLock Key"
+    "description": "The label for disabling the CapsLock Key"
   },
   "usability11MRCLabel": "New Context Menu",
   "@usability11MRCLabel": {


### PR DESCRIPTION
People think that enabling the option will enable their Caps Lock key, this should clear up that confusion.