### PR TITLE
Add forgotten "," that causes 'flutter run' to fail

### DIFF
--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -90,7 +90,7 @@
   "settingsEPTLabel": "Experimentelle Optimierungen anzeigen",
   "settingsEPTDescription": "",
   "restartAppDialog": "Sie müssen Ihre App neu starten, damit die Änderungen wirksam werden",
-  "settingsLanguageLabel": "Sprache"
+  "settingsLanguageLabel": "Sprache",
   "experimental": "Experimentell",
   "warning": "Warnung",
   "install": "Installieren",


### PR DESCRIPTION
```
Exception: The arb file C:\Users\elNino0916\Desktop\revision-tool-main\lib/l10n\intl_de.arb has the following formatting issue: FormatException: Unexpected character (at line 94, character 3)
  "experimental": "Experimentell",
  ^
```


## Submitter Checklist:

- [ ] There is a [ticket](https://github.com/meetrevision/revision-tool/issues) for my issue
- [X] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Discussed about the issue with reviewers in Discussions, Issues or other platforms 
- [x] Confirmed that the PR only includes changes related to my issue
- [X] Checked the PR locally: `flutter build windows` (Request it to reviewers if you're having problems)
-> 
```
C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(249,5): error MSB8066: Custom build for 'C:\Users\elNino0916\Desktop\revision-tool-main\build\windows\CMakeFiles\947a254ef4706b0daafd7ac97deb8b58\flutter_windows.dll.rule;C:\Users\elNino0916\Desktop\revision-tool-main\build\windows\CMakeFiles\24eb28b7fd0a3bd2a3f520d3184085c2\flutter_assemble.rule' exited with code 1. [C:\Users\elNino0916\Desktop\revision-tool-main\build\windows\flutter\flutter_assemble.vcxproj]
```