### PR TITLE
Enable immediate language change without requiring restart

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:revitool/commands/ms_store_command.dart';
 import 'package:revitool/commands/recommendation_command.dart';
 import 'package:revitool/l10n/generated/localizations.dart';
+import 'package:revitool/providers/l10n_provider.dart';
 import 'package:revitool/screens/home_page.dart';
 import 'package:provider/provider.dart';
 import 'package:revitool/theme.dart';
@@ -89,10 +90,14 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (_) => AppTheme(SettingsService()),
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => AppTheme(SettingsService())),
+        ChangeNotifierProvider(create: (_) => L10nProvider(appLanguage)),
+      ],
       builder: (context, _) {
         final appTheme = context.watch<AppTheme>();
+        final appLocale = context.watch<L10nProvider>().locale;
         return FluentApp(
           title: 'Revision Tool',
           debugShowCheckedModeBanner: false,
@@ -101,7 +106,7 @@ class MyApp extends StatelessWidget {
             ReviLocalizations.delegate,
             GlobalWidgetsLocalizations.delegate,
           ],
-          locale: Locale(appLanguage.split('_')[0], appLanguage.split('_')[1]),
+          locale: appLocale,
           supportedLocales: ReviLocalizations.supportedLocales,
           themeMode: appTheme.themeMode,
           color: appTheme.color,

--- a/lib/providers/l10n_provider.dart
+++ b/lib/providers/l10n_provider.dart
@@ -1,0 +1,16 @@
+import 'package:fluent_ui/fluent_ui.dart';
+
+class L10nProvider with ChangeNotifier {
+  L10nProvider(String initialLocale) {
+    _locale = initialLocale;
+  }
+
+  late String _locale;
+  String get localeStr => _locale;
+  Locale get locale => Locale(_locale.split("_")[0], _locale.split("_")[1]);
+
+  void changeLocale(String newLocale) {
+    _locale = newLocale;
+    notifyListeners();
+  }
+}

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -1,6 +1,7 @@
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:provider/provider.dart';
 import 'package:revitool/extensions.dart';
+import 'package:revitool/providers/l10n_provider.dart';
 import 'package:revitool/services/tool_update_service.dart';
 import 'package:revitool/theme.dart';
 import 'package:revitool/utils.dart';
@@ -189,21 +190,8 @@ class _SettingsPageState extends State<SettingsPage> {
                     r'SOFTWARE\Revision\Revision Tool',
                     'Language',
                     appLanguage);
+                context.read<L10nProvider>().changeLocale(appLanguage);
               });
-              showDialog(
-                context: context,
-                builder: (context) => ContentDialog(
-                  content: Text(context.l10n.restartAppDialog),
-                  actions: [
-                    Button(
-                      child: Text(context.l10n.okButton),
-                      onPressed: () {
-                        Navigator.pop(context);
-                      },
-                    )
-                  ],
-                ),
-              );
             },
             items: languageList,
           ),


### PR DESCRIPTION
Implemented a solution to enable immediate language changes in the UI without requiring a restart. Made use of the [provider](https://pub.dev/packages/provider) package.

### Issue Resolved:
Closes #72

## Additional Context
Using the provider package, the current language selected is stored as an app's state. Later whenever this state is altered, the whole widget tree is forced to be redrawn. The functionality to remember the language change after a restart remains unchanged.

## Demo
![Feature Demo](https://github.com/Dusk-afk/Dusk-afk/blob/master/assets/revision_tool_1.gif?raw=true)

## Submitter Checklist:
- [x] There is a [ticket](https://github.com/meetrevision/revision-tool/issues) (#72) for my issue
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Discussed about the issue with reviewers in Discussions, Issues or other platforms 
- [x] Confirmed that the PR only includes changes related to my issue
- [x] Checked the PR locally: `flutter build windows` (Request it to reviewers if you're having problems)