### PR TITLE
fix: unhide notification settings pages when enabling notifications

### DIFF
--- a/src/lib/core/usability/usability_service.dart
+++ b/src/lib/core/usability/usability_service.dart
@@ -146,6 +146,10 @@ class UsabilityService {
       'Allow',
     );
 
+    for (final page in ["notifications", "privacy-notifications"]) {
+      WinRegistryService.unhidePageVisibilitySettings(page);
+    }
+    
     final wpnServices = WinRegistryService.getUserServices('Wpn');
 
     for (final service in wpnServices) {
@@ -159,6 +163,8 @@ class UsabilityService {
 
     await Process.run('taskkill.exe', ['/im', 'explorer.exe', '/f']);
     await Process.run('explorer.exe', [], runInShell: true);
+
+
   }
 
   Future<void> disableNotification() async {


### PR DESCRIPTION
This commit addresses issue [#112](https://github.com/meetrevision/revision-tool/issues/112), where enabling notifications did not update the registry to unhide the "notifications" and "privacy-notifications" settings pages.  
- Added logic to the `enableNotification` function in `usability_service.dart` to call `WinRegistryService.unhidePageVisibilitySettings` for both "notifications" and "privacy-notifications" when notifications are enabled.
- This ensures that the relevant settings pages become visible immediately after enabling notifications, matching the expected behavior and improving user experience.
- Registry key `SettingsPageVisibility` under `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer` is now properly updated to remove hidden status for these pages.
- This fix mirrors the existing logic that hides these pages when notifications are disabled (offFull).

No other functional changes are included.

Resolves 

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/meetrevision/revision-tool/issues) for my issue
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Discussed about the issue with reviewers in Discussions, Issues or other platforms 
- [x] Confirmed that the PR only includes changes related to my issue
- [ ] Checked the PR locally: `flutter build windows` (Request it to reviewers if you're having problems)

atm im building it for test the PR locally but its a simple commit, i dont think there will be problems