### PR TITLE
[FIX] `exitCode: 0` Problem

### DIFF
--- a/src/lib/features/ms_store/widgets/ms_store_dialogs.dart
+++ b/src/lib/features/ms_store/widgets/ms_store_dialogs.dart
@@ -30,20 +30,25 @@ Future<Object?> showInstallProcess(
   BuildContext context,
   List<ProcessResult> processResult,
 ) {
+  final hasError = processResult.any((r) => r.exitCode != 0);
+
   return showDialog(
     context: context,
     dismissWithEsc: false,
     builder: (context) => ContentDialog(
       constraints: const BoxConstraints(maxWidth: 600, maxHeight: 600),
-      title: Text(t.installing),
+      title: Text(hasError ? 'Error' : t.install),
       content: Center(
         child: SingleChildScrollView(
           child: Column(
             mainAxisAlignment: .center,
             children: [
-              for (final item in processResult) ...[
-                Text(processResultToDebugString(item)),
-              ],
+              if (hasError)
+                for (final item in processResult) ...[
+                  Text(processResultToDebugString(item)),
+                ]
+              else
+                const Icon(FluentIcons.completed, size: 40, color: Colors.green),
             ],
           ),
         ),


### PR DESCRIPTION
## Description

### Issue:
- #131
Every time a user successfully installs software from the Revision Tool Microsoft Store, the GUI dialog displays a confusing technical debug string (`exitCode: 0`) instead of a user-friendly success message. While the software installs correctly, this raw output feels unpolished and can mislead users into thinking an error occurred.

### Fix:
Updated the `showInstallProcess` dialog to evaluate the exit codes of the installation processes. If all processes complete successfully (exit code 0), the dialog now displays a clear, green completed checkmark. The raw debug output is now only shown if an actual error occurs, and the dialog title dynamically updates to "Error" in such cases.

## Changes Made
* Modified `src/lib/features/ms_store/widgets/ms_store_dialogs.dart` to introduce a `hasError` check and conditionally render either the success icon or the process error logs in the `showInstallProcess` dialog.

## Impact & Testing
* **User Experience:** Provides intuitive, visually clear feedback upon successful installations, eliminating confusion caused by raw technical output.
* **Troubleshooting:** Retains the raw debug string output exclusively for failed installations, ensuring users can still diagnose actual issues.

Resolves #131

## Submitter Checklist:

- [x] There is a [ticket](https://github.com/meetrevision/revision-tool/issues) for my issue
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Discussed about the issue with reviewers in Discussions, Issues or other platforms 
- [x] Confirmed that the PR only includes changes related to my issue
- [x] Checked the PR locally: `flutter build windows` (Request it to reviewers if you're having problems)