### PR TITLE
Improve Store and registry failure handling

### DIFF
--- a/src/lib/core/error/app_exception.dart
+++ b/src/lib/core/error/app_exception.dart
@@ -41,3 +41,13 @@ final class UnexpectedNetworkException extends AppException {
     Object? cause,
   }) : super(message, cause: cause);
 }
+
+final class PackageIntegrityException extends AppException {
+  const PackageIntegrityException(String message, {Object? cause})
+    : super(message, cause: cause);
+}
+
+final class PackageInstallException extends AppException {
+  const PackageInstallException(String message, {Object? cause})
+    : super(message, cause: cause);
+}

--- a/src/lib/core/services/win_registry_service.dart
+++ b/src/lib/core/services/win_registry_service.dart
@@ -327,25 +327,33 @@ abstract class WinRegistryService {
       logger.i('$tag(writeRegistryValue): $path\\$name = $value');
 
       if (key == WinRegistryService.currentUser) {
-        await TrustedInstallerServiceImpl().executeCommand('reg', [
-          'load',
-          'HKU\\$defaultUser',
-          defaultUserHivePath,
-        ]);
-
-        final RegistryKey reg = Registry.allUsers;
+        var defaultHiveLoaded = false;
         try {
-          final RegistryKey subKey = reg.createKey('$defaultUser\\$path');
+          await _executeRegCommand([
+            'load',
+            'HKU\\$defaultUser',
+            defaultUserHivePath,
+          ]);
+          defaultHiveLoaded = true;
+
+          final RegistryKey reg = Registry.allUsers;
           try {
-            subKey.createValue(registryValue);
+            final RegistryKey subKey = reg.createKey('$defaultUser\\$path');
+            try {
+              subKey.createValue(registryValue);
+            } finally {
+              subKey.close();
+            }
+            logger.i(
+              '$tag(writeRegistryValue): $defaultUser\\$path\\$name = $value',
+            );
           } finally {
-            subKey.close();
+            reg.close();
           }
-          logger.i(
-            '$tag(writeRegistryValue): $defaultUser\\$path\\$name = $value',
-          );
         } finally {
-          reg.close();
+          if (defaultHiveLoaded) {
+            await _executeRegCommand(['unload', 'HKU\\$defaultUser']);
+          }
         }
       }
     } on WindowsException catch (e) {
@@ -386,16 +394,31 @@ abstract class WinRegistryService {
         error: e,
         stackTrace: StackTrace.current,
       );
+      rethrow;
     } catch (e) {
       logger.e(
         '$tag(writeRegistryValue): $path\\$name',
         error: e,
         stackTrace: StackTrace.current,
       );
+      rethrow;
     } finally {
       if (shouldClose) {
         key.close();
       }
+    }
+  }
+
+  static Future<void> _executeRegCommand(List<String> args) async {
+    final CommandResult result = await TrustedInstallerServiceImpl()
+        .executeCommand('reg', args);
+    if (result.exitCode != 0) {
+      throw ProcessException(
+        'reg',
+        args,
+        result.error.isEmpty ? result.output : result.error,
+        result.exitCode,
+      );
     }
   }
 
@@ -453,12 +476,14 @@ abstract class WinRegistryService {
         error: e,
         stackTrace: StackTrace.current,
       );
+      rethrow;
     } catch (e) {
       logger.e(
         '$tag(deleteValue): $path\\$name',
         error: e,
         stackTrace: StackTrace.current,
       );
+      rethrow;
     }
   }
 
@@ -509,12 +534,14 @@ abstract class WinRegistryService {
         error: e,
         stackTrace: StackTrace.current,
       );
+      rethrow;
     } catch (e) {
       logger.e(
         '$tag(deleteKey): $path',
         error: e,
         stackTrace: StackTrace.current,
       );
+      rethrow;
     }
   }
 
@@ -529,6 +556,7 @@ abstract class WinRegistryService {
         error: e,
         stackTrace: StackTrace.current,
       );
+      rethrow;
     }
   }
 }

--- a/src/lib/features/ms_store/services/package_file_service.dart
+++ b/src/lib/features/ms_store/services/package_file_service.dart
@@ -7,6 +7,7 @@ import 'package:dio/dio.dart';
 import 'package:process_run/shell_run.dart';
 import 'package:riverpod/riverpod.dart';
 
+import '../../../core/error/app_exception.dart';
 import '../../../core/error/result.dart';
 import '../../../core/network/api_client.dart';
 import '../../../utils.dart';
@@ -50,9 +51,28 @@ class PackageFileService {
     );
 
     return result.when(
-      success: (Response<dynamic> response) => const Result<void>.success(null),
-      failure: Result<void>.failure,
+      success: (Response<dynamic> response) {
+        if (cancelToken?.isCancelled ?? false) {
+          _deletePartialFile(file);
+          return const Result<void>.failure(CancelledRequestException());
+        }
+        return const Result<void>.success(null);
+      },
+      failure: (exception) {
+        _deletePartialFile(file);
+        return Result<void>.failure(exception);
+      },
     );
+  }
+
+  static void _deletePartialFile(File file) {
+    try {
+      if (file.existsSync()) {
+        file.deleteSync();
+      }
+    } on FileSystemException catch (e) {
+      logger.w('Failed to delete partial download ${file.path}: $e');
+    }
   }
 
   /// Deletes the root temporary store folder

--- a/src/lib/features/ms_store/store_service.dart
+++ b/src/lib/features/ms_store/store_service.dart
@@ -167,6 +167,7 @@ final class StoreService with BaseService {
     required CancelToken cancelToken,
     String? downloadPath,
   }) async {
+    var completed = false;
     return run(() async {
       if (downloadPath != null && downloadPath.isNotEmpty) {
         final dir = Directory(downloadPath);
@@ -193,10 +194,10 @@ final class StoreService with BaseService {
       var downloadedBytes = 0;
       var completedCount = 0;
       final downloads = <StorePackageFileDownload>{};
-      if (cancelToken.isCancelled) return downloads;
+      if (cancelToken.isCancelled) throw const CancelledRequestException();
 
       for (final item in flat) {
-        if (cancelToken.isCancelled) return downloads;
+        if (cancelToken.isCancelled) throw const CancelledRequestException();
 
         final PackageInfo package = item.package;
         final String productId = item.productId;
@@ -300,9 +301,10 @@ final class StoreService with BaseService {
             );
           },
         );
-        if (result is Failure && !cancelToken.isCancelled) {
+        if (result is Failure) {
           throw result.exception;
         }
+        if (cancelToken.isCancelled) throw const CancelledRequestException();
 
         final download = StorePackageFileDownload(
           downloadId: downloadId,
@@ -330,7 +332,10 @@ final class StoreService with BaseService {
           ),
         );
       }
+      completed = true;
       return downloads;
+    }, onFinally: () async {
+      if (!completed) releaseDownloadLocks();
     });
   }
 
@@ -360,7 +365,7 @@ final class StoreService with BaseService {
             algorithm: package.algorithm!,
           );
           if (!ok) {
-            throw Exception(
+            throw PackageIntegrityException(
               'Hash verification failed for ${package.progressName}',
             );
           }
@@ -378,6 +383,12 @@ final class StoreService with BaseService {
         };
         results[package.id] = installResult;
         if (installResult.exitCode == 0) _unlockFile(download.path);
+        if (installResult.exitCode != 0) {
+          throw PackageInstallException(
+            'Install failed for ${package.progressName} with exit code ${installResult.exitCode}',
+            cause: installResult.stderr,
+          );
+        }
       }
       return results;
     });

--- a/src/lib/features/winsxs/win_package_service.dart
+++ b/src/lib/features/winsxs/win_package_service.dart
@@ -162,6 +162,7 @@ abstract base class WinPackageService {
   /// Returns [String] path of the downloaded package.
   Future<String> download({String? path}) async {
     final String downloadPath = path ?? cabPath;
+    Object? githubFailure;
 
     try {
       logger.i('Attempting to download package from GitHub...');
@@ -194,13 +195,11 @@ abstract base class WinPackageService {
       });
 
       final downloadUrl = asset?['browser_download_url'] as String?;
-      if (asset != null) {
-        name = asset['name'] as String? ?? '';
-      }
+      name = asset?['name'] as String? ?? '';
 
-      if (downloadUrl == null) {
+      if (asset == null || name.isEmpty || downloadUrl == null) {
         throw WinSxSPackageNotFoundException(
-          'No matching package found for ${type.packageName} with architecture ${WinRegistryService.cpuArch}',
+          'No matching CAB asset found for ${type.packageName} with architecture ${WinRegistryService.cpuArch}',
         );
       }
 
@@ -223,6 +222,7 @@ abstract base class WinPackageService {
       logger.i('Successfully downloaded package from GitHub: $filePath');
       return filePath;
     } catch (e) {
+      githubFailure = e;
       logger.w('Failed to download from GitHub: $e');
       logger.i('Falling back to bundled packages...');
 
@@ -241,8 +241,8 @@ abstract base class WinPackageService {
       }
 
       throw WinSxSPackageDownloadException(
-        'Failed to download package from GitHub and no bundled package available',
-        e,
+        'Failed to download ${type.packageName} for ${WinRegistryService.cpuArch}; no bundled package was available at $bundledPackagesPath',
+        githubFailure,
       );
     }
   }

--- a/src/test/features/ms_store/services/ms_store_services_test.dart
+++ b/src/test/features/ms_store/services/ms_store_services_test.dart
@@ -322,6 +322,84 @@ void main() {
       },
     );
 
+    test('package download failure deletes partial file', () async {
+      final Directory tempDir = Directory.systemTemp.createTempSync(
+        'ms_store_file_service_failure_test_',
+      );
+      final path = '${tempDir.path}\\package.msix';
+
+      when(
+        () => apiClient.downloadFile(
+          any<Uri>(),
+          any<String>(),
+          onReceiveProgress: any<ProgressCallback?>(
+            named: 'onReceiveProgress',
+          ),
+          cancelToken: any<CancelToken?>(named: 'cancelToken'),
+        ),
+      ).thenAnswer((invocation) async {
+        final file = File(invocation.positionalArguments[1] as String)
+          ..parent.createSync(recursive: true);
+        file.writeAsStringSync('partial');
+        return const Result<Response<dynamic>>.failure(NetworkException());
+      });
+
+      try {
+        final Result<void> result = await PackageFileService(apiClient)
+            .download('https://example.test/package.msix', path);
+
+        expect(result, isA<Failure<void>>());
+        expect(File(path).existsSync(), isFalse);
+      } finally {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('package download cancellation deletes partial file', () async {
+      final Directory tempDir = Directory.systemTemp.createTempSync(
+        'ms_store_file_service_cancel_test_',
+      );
+      final path = '${tempDir.path}\\package.msix';
+      final cancelToken = CancelToken();
+
+      when(
+        () => apiClient.downloadFile(
+          any<Uri>(),
+          any<String>(),
+          onReceiveProgress: any<ProgressCallback?>(
+            named: 'onReceiveProgress',
+          ),
+          cancelToken: any<CancelToken?>(named: 'cancelToken'),
+        ),
+      ).thenAnswer((invocation) async {
+        final file = File(invocation.positionalArguments[1] as String)
+          ..parent.createSync(recursive: true);
+        file.writeAsStringSync('partial');
+        cancelToken.cancel('cancelled by test');
+        return Result<Response<dynamic>>.success(
+          Response<dynamic>(requestOptions: RequestOptions(), statusCode: 200),
+        );
+      });
+
+      try {
+        final Result<void> result = await PackageFileService(apiClient)
+            .download(
+              'https://example.test/package.msix',
+              path,
+              cancelToken: cancelToken,
+            );
+
+        expect(result, isA<Failure<void>>());
+        expect(
+          (result as Failure<void>).exception,
+          isA<CancelledRequestException>(),
+        );
+        expect(File(path).existsSync(), isFalse);
+      } finally {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
     test('service package download delegates to ApiClient', () async {
       final StoreService service = _service(
         apiClient,
@@ -363,6 +441,27 @@ void main() {
       } finally {
         await service.cleanup();
       }
+    });
+
+    test('service download cancellation returns typed failure', () async {
+      final StoreService service = _service(apiClient);
+      final cancelToken = CancelToken()..cancel('cancelled by test');
+
+      final Result<Set<StorePackageFileDownload>> result = await service
+          .download(
+            ring: StoreRing.retail,
+            packagesByProductId: {
+              '9TEST': [_sharedPackage(digest: 'digest', size: 12)],
+            },
+            cancelToken: cancelToken,
+            onProgress: (_) {},
+          );
+
+      expect(result, isA<Failure<Set<StorePackageFileDownload>>>());
+      expect(
+        (result as Failure<Set<StorePackageFileDownload>>).exception,
+        isA<CancelledRequestException>(),
+      );
     });
 
     test('single download skips a valid existing file', () async {
@@ -647,6 +746,69 @@ void main() {
       }
     });
 
+    test('install digest mismatch returns typed failure', () async {
+      final recording = _RecordingPackageFileService(
+        apiClient,
+        verifyResult: false,
+      );
+      final StoreService service = _service(apiClient, fileService: recording);
+
+      final Result<Map<String, ProcessResult>> result = await service.install(
+        downloads: {
+          StorePackageFileDownload(
+            downloadId: 'XPTEST',
+            ring: StoreRing.retail,
+            appType: StoreAppType.win32,
+            package: _win32Package(),
+            path: 'C:\\Temp\\app.exe',
+            bytes: 1,
+          ),
+        },
+      );
+
+      expect(result, isA<Failure<Map<String, ProcessResult>>>());
+      expect(
+        (result as Failure<Map<String, ProcessResult>>).exception,
+        isA<PackageIntegrityException>(),
+      );
+      expect(recording.win32InstallPaths, isEmpty);
+    });
+
+    test(
+      'failed Win32 install returns typed failure with stderr cause',
+      () async {
+        final recording = _RecordingPackageFileService(
+          apiClient,
+          win32ExitCode: 1603,
+          win32Stderr: 'install failed',
+        );
+        final StoreService service = _service(
+          apiClient,
+          fileService: recording,
+        );
+
+        final Result<Map<String, ProcessResult>> result = await service
+            .install(
+              downloads: {
+                StorePackageFileDownload(
+                  downloadId: 'XPTEST',
+                  ring: StoreRing.retail,
+                  appType: StoreAppType.win32,
+                  package: _win32Package(),
+                  path: 'C:\\Temp\\app.exe',
+                  bytes: 1,
+                ),
+              },
+            );
+
+        expect(result, isA<Failure<Map<String, ProcessResult>>>());
+        final exception =
+            (result as Failure<Map<String, ProcessResult>>).exception;
+        expect(exception, isA<PackageInstallException>());
+        expect(exception.cause, 'install failed');
+      },
+    );
+
     test('UWP parser stores SHA256 AdditionalDigest for verification', () {
       const packageDigest = 'h2VpDinRGUSRY9f04ZJbJoQDWD8=';
       const packageSha256 = 'WWxxdcCw+iftKSpE9GgfaHcgp3404Ae/bEA9GUDkYAU=';
@@ -811,7 +973,16 @@ final class _FakeUwpXmlParser extends UwpXmlParser {
 
 /// Intercepts install calls without executing real processes.
 final class _RecordingPackageFileService extends PackageFileService {
-  _RecordingPackageFileService(super.api);
+  _RecordingPackageFileService(
+    super.api, {
+    this.verifyResult = true,
+    this.win32ExitCode = 0,
+    this.win32Stderr = '',
+  });
+
+  final bool verifyResult;
+  final int win32ExitCode;
+  final String win32Stderr;
 
   final win32InstallPaths = <String>[];
 
@@ -820,12 +991,12 @@ final class _RecordingPackageFileService extends PackageFileService {
     required File file,
     required String digest,
     required String algorithm,
-  }) async => true;
+  }) async => verifyResult;
 
   @override
   Future<ProcessResult> runWin32Install(String path, List<String> args) async {
     win32InstallPaths.add(path);
-    return ProcessResult(0, 0, '', '');
+    return ProcessResult(0, win32ExitCode, '', win32Stderr);
   }
 }
 


### PR DESCRIPTION
## Summary
- propagates registry mutation failures after logging and unloads the default user hive after writes
- cleans partial Store package downloads on cancellation/failure
- returns typed Store package integrity/install failures
- improves WinSxS GitHub-to-bundled fallback error messages
- adds focused MS Store service tests for cancellation, cleanup, digest mismatch, and install failures

## Guardrails
No security tweak defaults or Windows guardrail settings were changed.

## Validation
- git diff --check
- Not run locally: Flutter/Dart are not installed in this workspace.